### PR TITLE
just assetResolve interface

### DIFF
--- a/addon/components/svg/index.js
+++ b/addon/components/svg/index.js
@@ -1,9 +1,8 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import resolveAsset from 'ember-cli-resolve-asset';
 import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
-
+import { inject as service } from '@ember/service';
 
 function needsLoading(name) {
   let componentDefinedName = `ember-svg-jar/components/${name}`;
@@ -20,7 +19,7 @@ function getInvocationName(name) {
   return `ember-svg-jar@${name}`;
 }
 
-export async function loadSvg(name) {
+export async function loadSvg(resolver, name) {
   let componentDefinedName = `ember-svg-jar/components/${name}`;
   let invokationName = getInvocationName(name);
 
@@ -28,12 +27,14 @@ export async function loadSvg(name) {
     return invokationName;
   }
 
-  const assetPath = await resolveAsset(`${componentDefinedName}.js`);
+  const assetPath = await resolver.resolveAsset(`${componentDefinedName}.js`);
   await import(assetPath);
   return invokationName;
 }
 
 export default class Svg extends Component {
+  @service svgJar;
+
   constructor() {
     super(...arguments);
     this.updateSvg();
@@ -43,25 +44,27 @@ export default class Svg extends Component {
 
   @action
   async updateSvg() {
-    if (needsLoading(this.args.name)) {
-      if (this.args.loadingSvg) {
-        if (needsLoading(this.args.loadingSvg)) {
-          // maybe we didn't bundle the loadingSvg, it will be there for the next one.
-          loadSvg(this.args.loadingSvg);
-        } else {
-          this._svgComponentName = getInvocationName(this.args.loadingSvg);
+    if (typeof FastBoot === 'undefined') {
+      if (needsLoading(this.args.name)) {
+        if (this.args.loadingSvg) {
+          if (needsLoading(this.args.loadingSvg)) {
+            // maybe we didn't bundle the loadingSvg, it will be there for the next one.
+            loadSvg(this.svgJar, this.args.loadingSvg);
+          } else {
+            this._svgComponentName = getInvocationName(this.args.loadingSvg);
+          }
         }
-      }
-      let invokationName = await loadSvg(this.args.name);
-      if (!this.isDestroyed || !this.isDestroying) {
-        this._svgComponentName = invokationName;
-        this.isLoading = false;
-        if (this.args.onIconLoad && typeof this.args.onIconLoad === 'function') {
-          this.args.onIconLoad();
+        let invokationName = await loadSvg(this.svgJar, this.args.name);
+        if (!this.isDestroyed || !this.isDestroying) {
+          this._svgComponentName = invokationName;
+          this.isLoading = false;
+          if (this.args.onIconLoad && typeof this.args.onIconLoad === 'function') {
+            this.args.onIconLoad();
+          }
         }
+      } else {
+        this._svgComponentName = getInvocationName(this.args.name);
       }
-    } else {
-      this._svgComponentName = getInvocationName(this.args.name);
     }
   }
 

--- a/addon/services/svg-jar.js
+++ b/addon/services/svg-jar.js
@@ -1,0 +1,8 @@
+import Service from '@ember/service';
+
+export default class SvgJarService extends Service {
+  // eslint-disable-next-line
+  resolveAsset(path) {
+    return `/${path}`;
+  }
+}

--- a/addon/services/svg-jar.js
+++ b/addon/services/svg-jar.js
@@ -1,8 +1,10 @@
 import Service from '@ember/service';
+import { getOwner } from '@ember/application';
 
 export default class SvgJarService extends Service {
   // eslint-disable-next-line
   resolveAsset(path) {
-    return `/${path}`;
+    const { rootURL = '' } = getOwner(this).resolveRegistration('config:environment');
+    return `${rootURL}${path}`;
   }
 }

--- a/app/services/svg-jar.js
+++ b/app/services/svg-jar.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-svg-jar/services/svg-jar';

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -8,15 +8,6 @@ module.exports = function(defaults) {
       strategy: ['symbol', 'inline', 'hbs'],
       sourceDirs: ['tests/dummy/public'],
       stripPath: false
-    },
-    // ember-cli-resolve-asset config
-    fingerprint: {
-      enabled: true,
-      generateAssetMap: true, // Required.
-      fingerprintAssetMap: true // Recommended to prevent caching issues.
-    },
-    'ember-fetch': {
-      preferNative: true // Recommended to enable faster preloading for browsers that support it.
     }
   });
 


### PR DESCRIPTION
@jherdman here's only the interface PR we talked about at #189 

A few things to notice:
1. It guards against fastboot, not sure how dynamic imports work in fastboot (guidance welcome)
2. If we are going to write tests, we will need to just don't run them for embroider, at least for `hbs` strategy at this moment, not sure how to have some sort of "allowlist". For them to work for embroider builds, a whole new strategy with webpack loaders probably should be used instead, I'm working on it... from time to time.