### PR TITLE
Allow `aria-hidden` argument

### DIFF
--- a/packages/ember-svg-jar/addon/types.ts
+++ b/packages/ember-svg-jar/addon/types.ts
@@ -8,6 +8,7 @@ interface SvgJarAttrs {
   fill?: string | null;
   width?: string | null;
   height?: string | null;
+  'aria-hidden'?: 'true' | 'false' | null;
   class?: string | null;
   role?: string | null;
   title?: string | null;


### PR DESCRIPTION
This is already supported and tested:
https://github.com/evoactivity/ember-svg-jar/blob/4c3db5068110809205d82c7070aefcc9b05d2132/packages/ember-svg-jar/tests/integration/helpers/svg-jar-test.js#L109-L122

It is considered a best practice to use aria-hidden on decorative SVGs: https://www.unimelb.edu.au/accessibility/techniques/accessible-svgs