### PR TITLE
Allow arbitrary attributes to be passed

### DIFF
--- a/packages/ember-svg-jar/addon/helpers/svg-jar.d.ts
+++ b/packages/ember-svg-jar/addon/helpers/svg-jar.d.ts
@@ -13,6 +13,7 @@ interface SvgJarAttrs {
   role?: string | null;
   title?: string | null;
   desc?: string | null;
+  [key: string]: unknown
 }
 
 type SvgJarReturn = SVGElement;


### PR DESCRIPTION
Currently, if you try to pass a test selector glint blows up because that is not defined here. This should handle that case and others where you pass other arbitrary attributes.