### PR TITLE
Ensure whitespace between aria-labelledby attribute

### DIFF
--- a/packages/ember-svg-jar/addon/utils/make-svg.js
+++ b/packages/ember-svg-jar/addon/utils/make-svg.js
@@ -109,8 +109,12 @@ export function formatAttrs(attrs) {
     .join(' ');
 }
 
+export function createSvgAttributes(attrs) {
+  return [formatAttrs(attrs), createAriaLabel(attrs)].filter(Boolean).join(' ');
+}
+
 export function symbolUseFor(assetId, attrs = {}) {
-  return `<svg ${formatAttrs(attrs)}${createAriaLabel(
+  return `<svg ${createSvgAttributes(
     attrs
   )}><use xlink:href="${assetId}" />${createAccessibilityElements(
     attrs
@@ -135,9 +139,9 @@ export function inlineSvgFor(assetId, getInlineAsset, attrs = {}) {
     delete svgAttrs.size;
   }
 
-  return `<svg ${formatAttrs(svgAttrs)}${createAriaLabel(
+  return `<svg ${createSvgAttributes(svgAttrs)}>${createAccessibilityElements(
     attrs
-  )}>${createAccessibilityElements(attrs)}${asset.content}</svg>`;
+  )}${asset.content}</svg>`;
 }
 
 export default function makeSvg(assetId, attrs = {}, getInlineAsset) {

--- a/packages/ember-svg-jar/tests/unit/utils/make-svg-test.js
+++ b/packages/ember-svg-jar/tests/unit/utils/make-svg-test.js
@@ -95,6 +95,24 @@ module('Unit | Utility | make svg', function () {
     );
   });
 
+  test('inlineSvgFor with custom attrs including title', function (assert) {
+    function assetStore(id) {
+      return {
+        icon: { content: 'icon', attrs: { class: 'original' } },
+      }[id];
+    }
+
+    let customAttrs = {
+      class: 'custom',
+      title: { id: 'foo', text: 'lorem ipsum' },
+    };
+    assert.strictEqual(
+      inlineSvgFor('icon', assetStore, customAttrs),
+      '<svg class="custom" aria-labelledby="foo"><title id="foo">lorem ipsum</title>icon</svg>',
+      'can rewrite original attrs'
+    );
+  });
+
   test('formatAttrs works', function (assert) {
     let result = formatAttrs({
       attrName: 'attrValue',


### PR DESCRIPTION
Currently, it renders as

```
data-my-attribute="foo"aria-labelledby="e318f545-6c68-44f5-9b03-8805ce9ed73a"
```

which produces invalid html